### PR TITLE
[SciSpark][ESIP Workshop] PDFClustering based on anomalies 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ scalaVersion := "2.10.6"
 
 scalacOptions := Seq("-feature", "-deprecation")
 
-mainClass in Compile := Some("org.dia.algorithms.mcc.MainDistGraphMCC")
+mainClass in Compile := Some("org.dia.algorithms.pdfclustering.PDFClusteringAnomalies")
 
 resolvers ++= Seq(
   Resolver.mavenLocal,

--- a/src/main/scala/org/dia/algorithms/pdfclustering/PDFClusteringAnomalies.scala
+++ b/src/main/scala/org/dia/algorithms/pdfclustering/PDFClusteringAnomalies.scala
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dia.algorithms.pdfclustering
+
+import java.util
+
+import org.dia.core.SciSparkContext
+import org.apache.spark.mllib.clustering.KMeans
+import org.apache.spark.mllib.linalg.Vectors
+import ucar.ma2.{ArrayInt, ArrayDouble, DataType}
+import ucar.nc2.{Dimension, NetcdfFileWriter}
+object PDFClusteringAnomalies {
+
+  def whiten(input: Array[Double]): Array[Double] = {
+      val mean = input.reduce((a, b) => a + b) / input.length
+      val summation = input.map(p => Math.pow(p - mean, 2.0)).reduce((a, b) => a + b)
+      val std = Math.sqrt(summation / input.length)
+      input.map(p => p / std)
+  }
+
+  def main(args: Array[String]): Unit = {
+    val nyears = 33
+    val mdays = 31
+    val lat = 181
+    val lon = 286
+    val masterURL = "local[2]"
+    val sc = new SciSparkContext(masterURL, "PDF clustering")
+    val tasjan = sc.NetcdfDFSFile("resources/PDFClustering/tas_MERRA_NA_daily_January_1979-2011.nc", List("tasjan", "lat", "lon"))
+
+    /**
+     * Detrend daily data
+     */
+    val detrendedData = tasjan.map(p => {
+      var data = p("tasjan").copy
+      data = data.reshape(Array(nyears, mdays, lat, lon))
+      val clim = data.mean(0).reshape(Array(1, mdays, lat, lon))
+
+      // broadcast subtract
+      // Since subtraction is now done in place by default
+      // The results are in the 'data' array
+      for(i <- 0 until nyears){
+        data(i -> (i + 1)) - clim
+      }
+      data = data.reshape(Array(nyears*mdays, lat, lon))
+      val detrended = data.detrend(Array(0))
+      detrended.insertVar("lat", p("lat").tensor)
+      detrended.insertVar("lon", p("lon").tensor)
+      detrended
+    })
+
+    val calc_moments = detrendedData.map(p => {
+      print(p)
+      val std = p.std(Array(0)).tensor
+      val skw = p.skew(Array(0)).tensor
+      p.insertVar("std", std)
+      p.insertVar("skw", skw)
+      p
+    }).collect
+
+    val std = calc_moments(0)("std").tensor.data
+    val skw = calc_moments(0)("skw").tensor.data
+    val latarr = calc_moments(0)("lat").tensor.data
+    val lonarr = calc_moments(0)("lon").tensor.data
+    val zipped = std.zip(skw)
+
+    val numClusters = 5
+    val iter = 300
+
+    val vectors = sc.sparkContext.parallelize(zipped).map{ case (std_i, sk_i) => Vectors.dense(std_i, sk_i)}
+
+    val clusters = new KMeans().setSeed(0).setMaxIterations(iter).setK(numClusters).run(vectors)
+    val centers = clusters.clusterCenters.toList
+    val prd = clusters.predict(vectors).collect
+
+    val writer = NetcdfFileWriter.createNew(NetcdfFileWriter.Version.netcdf3, "results", null)
+    val xDim = writer.addDimension(null, "len", std.length)
+    val centerDim = writer.addDimension(null, "len_centers", centers.length)
+    val latDim = writer.addDimension(null, "latDim", latarr.length)
+    val lonDim = writer.addDimension(null, "lonDim", lonarr.length)
+    val dims = new util.ArrayList[Dimension]()
+    val cDim = new util.ArrayList[Dimension]()
+    val latDims = new util.ArrayList[Dimension]()
+    val lonDims = new util.ArrayList[Dimension]()
+    dims.add(xDim)
+    cDim.add(centerDim)
+    latDims.add(latDim)
+    lonDims.add(lonDim)
+    val std_var = writer.addVariable(null, "std", DataType.DOUBLE, dims)
+    val skw_var = writer.addVariable(null, "skw", DataType.DOUBLE, dims)
+    val prd_var = writer.addVariable(null, "prediction", DataType.INT, dims)
+    val cnt_std_var = writer.addVariable(null, "centers_std", DataType.DOUBLE, cDim)
+    val cnt_skw_var = writer.addVariable(null, "centers_skw", DataType.DOUBLE, cDim)
+    val lat_dim_var = writer.addVariable(null, "lat", DataType.DOUBLE, latDims)
+    val lon_dim_var = writer.addVariable(null, "lon", DataType.DOUBLE, lonDims)
+    writer.create()
+
+    val stddataOut = new ArrayDouble.D1(std.length)
+    val skwdataOut = new ArrayDouble.D1(skw.length)
+    val prdDataOut = new ArrayInt.D1(prd.length)
+    val cnt_stdDataOut = new ArrayDouble.D1(centers.length)
+    val cnt_skwDataOut = new ArrayDouble.D1(centers.length)
+    val latdataOut = new ArrayDouble.D1(latarr.length)
+    val londataOut = new ArrayDouble.D1(lonarr.length)
+    assert(std.length == skw.length && skw.length == prd.length)
+    for(i <- 0 until std.length){
+      stddataOut.set(i, std(i))
+      skwdataOut.set(i, skw(i))
+      prdDataOut.set(i, prd(i))
+    }
+
+    for(i <- 0 until centers.length){
+      cnt_stdDataOut.set(i, centers(i)(0))
+      cnt_skwDataOut.set(i, centers(i)(1))
+    }
+
+    for(i <- 0 until latarr.length){
+      latdataOut.set(i, latarr(i))
+    }
+
+    for(i <- 0 until lonarr.length){
+      londataOut.set(i, lonarr(i))
+    }
+    writer.write(std_var, stddataOut)
+    writer.write(skw_var, skwdataOut)
+    writer.write(prd_var, prdDataOut)
+    writer.write(lat_dim_var, latdataOut)
+    writer.write(lon_dim_var, londataOut)
+    writer.write(cnt_std_var, cnt_stdDataOut)
+    writer.write(cnt_skw_var, cnt_skwDataOut)
+
+    writer.close()
+  }
+
+
+  /**
+    * (1 to 1000d).toArray.reduce((A, B) => (
+    *
+    *
+    *
+    */
+}

--- a/src/main/scala/org/dia/core/SciSparkContext.scala
+++ b/src/main/scala/org/dia/core/SciSparkContext.scala
@@ -60,7 +60,7 @@ class SciSparkContext(val sparkContext: SparkContext) {
   def this(conf: SparkConf) {
     this(new SparkContext(conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
       .set("spark.kryo.classesToRegister", "java.lang.Thread")
-    .set("spark.kryoserializer.buffer.max.mb", "256MB")))
+    .set("spark.kryoserializer.buffer.max", "256MB")))
   }
 
   def this(uri: String, name: String) {

--- a/src/main/scala/org/dia/core/SciSparkContext.scala
+++ b/src/main/scala/org/dia/core/SciSparkContext.scala
@@ -58,7 +58,9 @@ class SciSparkContext(val sparkContext: SparkContext) {
 
 
   def this(conf: SparkConf) {
-    this(new SparkContext(conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer").set("spark.kryo.classesToRegister", "java.lang.Thread")))
+    this(new SparkContext(conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+      .set("spark.kryo.classesToRegister", "java.lang.Thread")
+    .set("spark.kryoserializer.buffer.max.mb", "256MB")))
   }
 
   def this(uri: String, name: String) {

--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -50,7 +50,7 @@ class SciTensor(val variables: mutable.HashMap[String, AbstractTensor]) extends 
   /**
    * Reshapes the variable in use
    */
-  def reshape(reshapedVarName : String, shape : Array[Int]) : SciTensor = {
+  def reshape(reshapedVarName : String = varInUse, shape : Array[Int]) : SciTensor = {
     insertVar(reshapedVarName, variables(varInUse).reshape(shape))
     this
   }

--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -48,6 +48,14 @@ class SciTensor(val variables: mutable.HashMap[String, AbstractTensor]) extends 
   }
 
   /**
+   * Reshapes the variable in use
+   */
+  def reshape(reshapedVarName : String, shape : Array[Int]) : SciTensor = {
+    insertVar(reshapedVarName, variables(varInUse).reshape(shape))
+    this
+  }
+
+  /**
    * Writes metaData in the form of key-value pairs
    */
   def insertDictionary(metaDataVar: (String, String)*): Unit = {

--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -55,7 +55,7 @@ class SciTensor(val variables: mutable.HashMap[String, AbstractTensor]) extends 
    * @param reshapedVarName The new variable name. Default is the current variable in use.
    * @param shape The array specifying dimensions of the new shape
    */
-  def reshape(reshapedVarName : String = varInUse, shape : Array[Int]) : SciTensor = {
+  def reshape(shape : Array[Int], reshapedVarName : String = varInUse) : SciTensor = {
     insertVar(reshapedVarName, variables(varInUse).reshape(shape))
     this
   }

--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -52,8 +52,8 @@ class SciTensor(val variables: mutable.HashMap[String, AbstractTensor]) extends 
    * If a new name is not specified then the variable in use is used by default.
    * The AbstractTensor which corresponds to the variable in use is replaced by
    * the reshaped one.
-   * @param reshapedVarName the new variable name. Default is the current variable in use
-   * @param shape the array specifying dimensions of the new shape
+   * @param reshapedVarName The new variable name. Default is the current variable in use.
+   * @param shape The array specifying dimensions of the new shape
    */
   def reshape(reshapedVarName : String = varInUse, shape : Array[Int]) : SciTensor = {
     insertVar(reshapedVarName, variables(varInUse).reshape(shape))

--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -48,7 +48,11 @@ class SciTensor(val variables: mutable.HashMap[String, AbstractTensor]) extends 
   }
 
   /**
-   * Reshapes the variable in use
+   * Reshapes the array and inserts the reshaped array into the variable hashmap.
+   * If a new name is not specified then the variable in use is used by default.
+   * The AbstractTensor which corresponds to the variable in use is replaced by
+   * the reshaped one.
+   *
    */
   def reshape(reshapedVarName : String = varInUse, shape : Array[Int]) : SciTensor = {
     insertVar(reshapedVarName, variables(varInUse).reshape(shape))

--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -52,7 +52,8 @@ class SciTensor(val variables: mutable.HashMap[String, AbstractTensor]) extends 
    * If a new name is not specified then the variable in use is used by default.
    * The AbstractTensor which corresponds to the variable in use is replaced by
    * the reshaped one.
-   *
+   * @param reshapedVarName the new variable name. Default is the current variable in use
+   * @param shape the array specifying dimensions of the new shape
    */
   def reshape(reshapedVarName : String = varInUse, shape : Array[Int]) : SciTensor = {
     insertVar(reshapedVarName, variables(varInUse).reshape(shape))

--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -187,6 +187,12 @@ class SciTensor(val variables: mutable.HashMap[String, AbstractTensor]) extends 
   def data : Array[Double] = variables(varInUse).data
 
   /**
+   * Creates a copy of the variable in use
+   * @return
+   */
+  def copy : SciTensor = variables(varInUse).copy
+
+  /**
    * Statistical operations
    */
 

--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -215,8 +215,16 @@ class SciTensor(val variables: mutable.HashMap[String, AbstractTensor]) extends 
     variables(varInUse).broadcast(shape)
   }
 
-  def detrend(shape: Array[Int]): SciTensor = {
+  def detrend(axis: Array[Int]): SciTensor = {
     variables(varInUse).detrend(0)
+  }
+
+  def std(axis: Array[Int]): SciTensor = {
+    variables(varInUse).std(axis: _*)
+  }
+
+  def skew(axis: Array[Int]): SciTensor = {
+    variables(varInUse).skew(axis:_ *)
   }
   /**
    * Returns a block averaged tensor where the blocks are squares with

--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -200,6 +200,19 @@ class SciTensor(val variables: mutable.HashMap[String, AbstractTensor]) extends 
   }
 
   /**
+   * Computes and returns the array broadcasted to
+   * the specified shape requirements.
+   * @param shape
+   * @return
+   */
+  def broadcast(shape: Array[Int]): SciTensor = {
+    variables(varInUse).broadcast(shape)
+  }
+
+  def detrend(shape: Array[Int]): SciTensor = {
+    variables(varInUse).detrend(0)
+  }
+  /**
    * Returns a block averaged tensor where the blocks are squares with
    * dimensions blockInt.
    */

--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -187,6 +187,19 @@ class SciTensor(val variables: mutable.HashMap[String, AbstractTensor]) extends 
   def data : Array[Double] = variables(varInUse).data
 
   /**
+   * Statistical operations
+   */
+
+  /**
+   * Computes the mean along the given axis of the variable in use.
+   * @param axis
+   * @return
+   */
+  def mean(axis: Int*): SciTensor = {
+    variables(varInUse).mean(axis: _*)
+  }
+
+  /**
    * Returns a block averaged tensor where the blocks are squares with
    * dimensions blockInt.
    */

--- a/src/main/scala/org/dia/tensors/AbstractTensor.scala
+++ b/src/main/scala/org/dia/tensors/AbstractTensor.scala
@@ -92,6 +92,13 @@ trait AbstractTensor extends Serializable with SliceableArray {
   def detrend(axis: Int) : T
   def toString: String
 
+  /**
+   * Due to properties of Doubles, the equals method
+   * utilizes the percent error rather than checking absolute equality.
+   * The threshold for percent error is if it is greater than 0.5% or .005.
+   * @param any
+   * @return
+   */
   override def equals(any: Any): Boolean = {
     val array = any.asInstanceOf[AbstractTensor]
     val shape = array.shape
@@ -101,7 +108,22 @@ trait AbstractTensor extends Serializable with SliceableArray {
 
     val thisData = this.data
     val otherData = array.data
-    for(index <- 0 to thisData.length - 1) if(thisData(index) != otherData(index)) return false
+    for(index <- 0 to thisData.length - 1){
+      val left = thisData(index)
+      val right = otherData(index)
+      if(left != 0.0 && right == 0.0){
+        return false
+      } else if (right == 0.0 && left != 0.0) {
+        return false
+      } else if ( right != 0.0 && left != 0.0) {
+        val absoluteError = Math.abs(left - right)
+        val percentageError = absoluteError / Math.max(left, right)
+        if(percentageError > 5E-3) {
+          return false
+        }
+      }
+
+    }
     true
   }
 

--- a/src/main/scala/org/dia/tensors/AbstractTensor.scala
+++ b/src/main/scala/org/dia/tensors/AbstractTensor.scala
@@ -11,6 +11,7 @@ trait AbstractTensor extends Serializable with SliceableArray {
   val name: String
   val LOG = org.slf4j.LoggerFactory.getLogger(this.getClass)
 
+  def reshape(shape: Array[Int]): T
   def zeros(shape: Int*): T
 
   def map(f: Double => Double): AbstractTensor

--- a/src/main/scala/org/dia/tensors/AbstractTensor.scala
+++ b/src/main/scala/org/dia/tensors/AbstractTensor.scala
@@ -87,6 +87,7 @@ trait AbstractTensor extends Serializable with SliceableArray {
    */
 
   def cumsum: Double
+  def mean(axis : Int*) : T
   def toString: String
 
   override def equals(any: Any): Boolean = {

--- a/src/main/scala/org/dia/tensors/AbstractTensor.scala
+++ b/src/main/scala/org/dia/tensors/AbstractTensor.scala
@@ -89,6 +89,7 @@ trait AbstractTensor extends Serializable with SliceableArray {
 
   def cumsum: Double
   def mean(axis : Int*) : T
+  def detrend(axis: Int) : T
   def toString: String
 
   override def equals(any: Any): Boolean = {

--- a/src/main/scala/org/dia/tensors/AbstractTensor.scala
+++ b/src/main/scala/org/dia/tensors/AbstractTensor.scala
@@ -12,6 +12,7 @@ trait AbstractTensor extends Serializable with SliceableArray {
   val LOG = org.slf4j.LoggerFactory.getLogger(this.getClass)
 
   def reshape(shape: Array[Int]): T
+  def broadcast(shape: Array[Int]): T
   def zeros(shape: Int*): T
 
   def map(f: Double => Double): AbstractTensor

--- a/src/main/scala/org/dia/tensors/AbstractTensor.scala
+++ b/src/main/scala/org/dia/tensors/AbstractTensor.scala
@@ -90,6 +90,8 @@ trait AbstractTensor extends Serializable with SliceableArray {
   def cumsum: Double
   def mean(axis : Int*) : T
   def detrend(axis: Int) : T
+  def std(axis: Int*): T
+  def skew(axis: Int*): T
   def assign(newTensor: AbstractTensor) : T
   def toString: String
 

--- a/src/main/scala/org/dia/tensors/AbstractTensor.scala
+++ b/src/main/scala/org/dia/tensors/AbstractTensor.scala
@@ -93,13 +93,14 @@ trait AbstractTensor extends Serializable with SliceableArray {
 
   override def equals(any: Any): Boolean = {
     val array = any.asInstanceOf[AbstractTensor]
-    if (array.rows != this.rows) return false
-    if (array.cols != this.cols) return false
-    for (row <- 0 to array.rows - 1) {
-      for (col <- 0 to array.cols - 1) {
-        if (array(row, col) != this(row, col)) return false
-      }
-    }
+    val shape = array.shape
+    val thisShape = this.shape
+
+    if(!shape.sameElements(thisShape)) return false
+
+    val thisData = this.data
+    val otherData = array.data
+    for(index <- 0 to thisData.length - 1) if(thisData(index) != otherData(index)) return false
     true
   }
 

--- a/src/main/scala/org/dia/tensors/AbstractTensor.scala
+++ b/src/main/scala/org/dia/tensors/AbstractTensor.scala
@@ -90,6 +90,7 @@ trait AbstractTensor extends Serializable with SliceableArray {
   def cumsum: Double
   def mean(axis : Int*) : T
   def detrend(axis: Int) : T
+  def assign(newTensor: AbstractTensor) : T
   def toString: String
 
   /**
@@ -127,7 +128,7 @@ trait AbstractTensor extends Serializable with SliceableArray {
     true
   }
 
-  
+  def copy: T
 
   def isZero: Boolean
   /**

--- a/src/main/scala/org/dia/tensors/BreezeTensor.scala
+++ b/src/main/scala/org/dia/tensors/BreezeTensor.scala
@@ -17,7 +17,7 @@
  */
 package org.dia.tensors
 
-import breeze.linalg.{ DenseMatrix, sum }
+import breeze.linalg.{ DenseMatrix, sum, Axis}
 import scala.language.implicitConversions
 
 /**
@@ -142,6 +142,15 @@ class BreezeTensor(val tensor: DenseMatrix[Double]) extends AbstractTensor {
    */
 
   def cumsum = sum(tensor)
+
+  /**
+   * TODO :: Implement the mean along axis function for BreezeTensor
+   * @param axis
+   * @return
+   */
+  def mean(axis : Int*) = {
+      throw new Exception("BreezeTensor does not support the mean along axis operation yet")
+  }
 
   def isZero = sum(tensor :* tensor) <= 1E-9
 

--- a/src/main/scala/org/dia/tensors/BreezeTensor.scala
+++ b/src/main/scala/org/dia/tensors/BreezeTensor.scala
@@ -47,6 +47,9 @@ class BreezeTensor(val tensor: DenseMatrix[Double]) extends AbstractTensor {
     this(loadFunc())
   }
 
+  def reshape(shape: Array[Int]) = {
+    new BreezeTensor((this.data, shape))
+  }
   /**
    * Constructs a zeroed BreezeTensor.
    *
@@ -114,7 +117,7 @@ class BreezeTensor(val tensor: DenseMatrix[Double]) extends AbstractTensor {
 
   def div(num: Double): BreezeTensor = tensor / num
 
-  def data = tensor.t.toArray
+  def data : Array[Double] = tensor.t.toArray
 
   /**
    * SlicableArray operations

--- a/src/main/scala/org/dia/tensors/BreezeTensor.scala
+++ b/src/main/scala/org/dia/tensors/BreezeTensor.scala
@@ -50,6 +50,11 @@ class BreezeTensor(val tensor: DenseMatrix[Double]) extends AbstractTensor {
   def reshape(shape: Array[Int]) = {
     new BreezeTensor((this.data, shape))
   }
+
+  def broadcast(shape: Array[Int]) = {
+    throw new Exception("BreezeTensor does not support the broadcast operation yet")
+  }
+
   /**
    * Constructs a zeroed BreezeTensor.
    *

--- a/src/main/scala/org/dia/tensors/BreezeTensor.scala
+++ b/src/main/scala/org/dia/tensors/BreezeTensor.scala
@@ -166,6 +166,13 @@ class BreezeTensor(val tensor: DenseMatrix[Double]) extends AbstractTensor {
     throw new Exception("BreezeTensor does not yet support detrending")
   }
 
+  def std(axis : Int*) = {
+    throw new Exception("BreezeTensor does not yet support standard deviation along axis")
+  }
+
+  def skew(axis: Int*) = {
+    throw new Exception("BreezeTensor does not yet support skewness along an axis")
+  }
   /**
    * Copies over the data in a new tensor to the current tensor
    * @param newTensor

--- a/src/main/scala/org/dia/tensors/BreezeTensor.scala
+++ b/src/main/scala/org/dia/tensors/BreezeTensor.scala
@@ -166,6 +166,15 @@ class BreezeTensor(val tensor: DenseMatrix[Double]) extends AbstractTensor {
     throw new Exception("BreezeTensor does not yet support detrending")
   }
 
+  /**
+   * Copies over the data in a new tensor to the current tensor
+   * @param newTensor
+   * @return
+   */
+  def assign(newTensor: AbstractTensor) : BreezeTensor = {
+    this.tensor := newTensor.tensor
+  }
+
   def isZero = sum(tensor :* tensor) <= 1E-9
 
   def isZeroShortcut = sum(tensor) <= 1E-9
@@ -175,6 +184,8 @@ class BreezeTensor(val tensor: DenseMatrix[Double]) extends AbstractTensor {
   def max = breeze.linalg.max(tensor)
 
   def min = breeze.linalg.min(tensor)
+
+  def copy = tensor.copy
 
   /**
    * Due to implicit conversions we can do operations on BreezeTensors and DenseMatrix

--- a/src/main/scala/org/dia/tensors/BreezeTensor.scala
+++ b/src/main/scala/org/dia/tensors/BreezeTensor.scala
@@ -157,6 +157,15 @@ class BreezeTensor(val tensor: DenseMatrix[Double]) extends AbstractTensor {
       throw new Exception("BreezeTensor does not support the mean along axis operation yet")
   }
 
+  /**
+    * TODO :: Implement detrend along axis
+    * @param axis
+    * @return
+    */
+  def detrend(axis : Int) = {
+    throw new Exception("BreezeTensor does not yet support detrending")
+  }
+
   def isZero = sum(tensor :* tensor) <= 1E-9
 
   def isZeroShortcut = sum(tensor) <= 1E-9

--- a/src/main/scala/org/dia/tensors/Nd4jTensor.scala
+++ b/src/main/scala/org/dia/tensors/Nd4jTensor.scala
@@ -173,8 +173,7 @@ class Nd4jTensor(val tensor: INDArray) extends AbstractTensor {
       // however it would be nice to use the lapack gelsd operator
       // The operation isn't yet suppored by nd4j
       val coef = inverse.InvertMatrix.invert(A.transpose().dot(A), true).dot(A.transpose()).dot(newdata(sl))
-      val solution = Nd4j.create(N, prod/N, coef.ordering())
-      val dot = A.mmuli(coef, solution)
+      val dot = A.dot(coef)
 
       newdata(sl).subi(dot)
     }

--- a/src/main/scala/org/dia/tensors/Nd4jTensor.scala
+++ b/src/main/scala/org/dia/tensors/Nd4jTensor.scala
@@ -38,6 +38,8 @@ class Nd4jTensor(val tensor: INDArray) extends AbstractTensor {
     this(loadFunc())
   }
 
+  def reshape(shape: Array[Int]) = new Nd4jTensor(Nd4j.create(this.data, shape))
+
   def zeros(shape: Int*) = new Nd4jTensor(Nd4j.create(shape: _*))
 
   def map(f: Double => Double) = new Nd4jTensor(tensor.map(p => f(p)))
@@ -117,7 +119,7 @@ class Nd4jTensor(val tensor: INDArray) extends AbstractTensor {
 
   def apply(indexes: Int*) = tensor.get(indexes.toArray)
 
-  def data = tensor.data.asDouble()
+  def data : Array[Double] = tensor.data.asDouble()
 
   /**
    * Utility Functions

--- a/src/main/scala/org/dia/tensors/Nd4jTensor.scala
+++ b/src/main/scala/org/dia/tensors/Nd4jTensor.scala
@@ -40,6 +40,17 @@ class Nd4jTensor(val tensor: INDArray) extends AbstractTensor {
 
   def reshape(shape: Array[Int]) = new Nd4jTensor(Nd4j.create(this.data, shape))
 
+  def broadcast(shape: Array[Int]) = {
+    //new Nd4jTensor(tensor.broadcast(shape: _*))
+    val extraDims = shape diff this.shape
+    val totalExtraCopies = extraDims.reduce((A, B) => A * B)
+    var rawLinearArray = this.data
+    for (i <- 0 to totalExtraCopies by 1){
+      rawLinearArray = rawLinearArray ++ rawLinearArray
+    }
+    new Nd4jTensor((rawLinearArray, shape))
+  }
+
   def zeros(shape: Int*) = new Nd4jTensor(Nd4j.create(shape: _*))
 
   def map(f: Double => Double) = new Nd4jTensor(tensor.map(p => f(p)))

--- a/src/main/scala/org/dia/tensors/Nd4jTensor.scala
+++ b/src/main/scala/org/dia/tensors/Nd4jTensor.scala
@@ -129,6 +129,12 @@ class Nd4jTensor(val tensor: INDArray) extends AbstractTensor {
     new Nd4jTensor(IndArray)
   }
 
+  def slice(ranges: (Int, Int)*) = {
+    val rangeMap = ranges.map(p => TupleRange(p))
+    val IndArray = tensor(rangeMap: _*)
+    new Nd4jTensor(IndArray)
+  }
+
   def apply(indexes: Int*) = tensor.get(indexes.toArray)
 
   def data : Array[Double] = tensor.data.asDouble()
@@ -183,6 +189,16 @@ class Nd4jTensor(val tensor: INDArray) extends AbstractTensor {
     new Nd4jTensor(ret)
   }
 
+  /**
+    * Copies over the data in a new tensor to the current tensor
+    * @param newTensor
+    * @return
+    */
+  def assign(newTensor: AbstractTensor) : Nd4jTensor = {
+    this.tensor.assign(newTensor.tensor)
+    this
+  }
+
   override def toString = tensor.toString
 
   def isZero = tensor.mul(tensor).sumNumber.asInstanceOf[Double] <= 1E-9
@@ -192,6 +208,8 @@ class Nd4jTensor(val tensor: INDArray) extends AbstractTensor {
   def max = tensor.maxNumber.asInstanceOf[Double]
 
   def min = tensor.minNumber.asInstanceOf[Double]
+
+  def copy = new Nd4jTensor(this.tensor.dup())
 
   private implicit def AbstractConvert(array: AbstractTensor): Nd4jTensor = array.asInstanceOf[Nd4jTensor]
   

--- a/src/main/scala/org/dia/tensors/Nd4jTensor.scala
+++ b/src/main/scala/org/dia/tensors/Nd4jTensor.scala
@@ -20,6 +20,7 @@ package org.dia.tensors
 import org.nd4j.linalg.api.ndarray.INDArray
 import org.nd4j.linalg.factory.Nd4j
 import org.nd4j.linalg.inverse
+import org.nd4j.linalg.ops.transforms.Transforms
 import org.nd4s.Implicits._
 import scala.language.implicitConversions
 
@@ -187,6 +188,25 @@ class Nd4jTensor(val tensor: INDArray) extends AbstractTensor {
 
     val ret = Nd4j.create(newdata.data().asDouble(), tdshape)
     new Nd4jTensor(ret)
+  }
+
+  def std(axis : Int*) = {
+    new Nd4jTensor(tensor.std(axis: _*))
+  }
+
+  def skew(axis: Int*) = {
+    var meanAlongAxis = tensor.mean(axis: _*)
+    val shapeMatch = Array(1) ++ meanAlongAxis.shape
+    meanAlongAxis = meanAlongAxis.reshape(shapeMatch: _*)
+    val copy = tensor.dup()
+    val std = tensor.std(axis: _*).reshape(shapeMatch: _*)
+    for(i <- 0 until this.shape(axis(0))){
+      val diffOversd = (copy((i, i+1)).subi(meanAlongAxis)).divi(std)
+      val cubed = Transforms.pow(diffOversd, 3, false)
+    }
+
+    val third = copy.sum(axis: _*).divi(this.shape(axis(0)))
+    new Nd4jTensor(third)
   }
 
   /**

--- a/src/main/scala/org/dia/tensors/Nd4jTensor.scala
+++ b/src/main/scala/org/dia/tensors/Nd4jTensor.scala
@@ -127,6 +127,8 @@ class Nd4jTensor(val tensor: INDArray) extends AbstractTensor {
   
   def cumsum = tensor.sumNumber.asInstanceOf[Double]
 
+  def mean(axis : Int*) = new Nd4jTensor(tensor.mean(axis: _*))
+
   override def toString = tensor.toString
 
   def isZero = tensor.mul(tensor).sumNumber.asInstanceOf[Double] <= 1E-9

--- a/src/test/scala/org/dia/loaders/TestMatrixReader.scala
+++ b/src/test/scala/org/dia/loaders/TestMatrixReader.scala
@@ -25,24 +25,28 @@ import org.nd4j.linalg.factory.Nd4j
  */
 object TestMatrixReader {
 
+  val randVar = Array(
+    Array(240.0, 241.0, 240.0, 241.0, 241.0),
+    Array(230.0, 231.0, 240.0, 222.0, 241.0),
+    Array(242.0, 243.0, 244.0, 241.0, 232.0),
+    Array(240.0, 241.0, 230.0, 231.0, 241.0),
+    Array(240.0, 241.0, 240.0, 242.0, 241.0),
+    Array(242.0, 243.0, 244.0, 241.0, 242.0))
+
+  val randVar_1 = Array(
+    Array(240.0, 240.0, 241.0, 243.0, 240.0),
+    Array(234.0, 230.0, 243.0, 224.0, 244.0),
+    Array(240.0, 245.0, 240.0, 240.0, 235.0),
+    Array(249.0, 244.0, 239.0, 238.0, 240.0),
+    Array(242.0, 242.0, 242.0, 241.0, 242.0),
+    Array(241.0, 240.0, 241.0, 243.0, 241.0))
+
   def loadTestArray(uri: String, varname: String) = {
     var sample : Array[Array[Double]] = Array()
     if (varname == "randVar"){
-      sample = Array(
-        Array(240.0, 241.0, 240.0, 241.0, 241.0),
-        Array(230.0, 231.0, 240.0, 222.0, 241.0),
-        Array(242.0, 243.0, 244.0, 241.0, 232.0),
-        Array(240.0, 241.0, 230.0, 231.0, 241.0),
-        Array(240.0, 241.0, 240.0, 242.0, 241.0),
-        Array(242.0, 243.0, 244.0, 241.0, 242.0))
+      sample = randVar
       }else if (varname == "randVar_1"){
-        sample = Array(
-          Array(240.0, 240.0, 241.0, 243.0, 240.0),
-          Array(234.0, 230.0, 243.0, 224.0, 244.0),
-          Array(240.0, 245.0, 240.0, 240.0, 235.0),
-          Array(249.0, 244.0, 239.0, 238.0, 240.0),
-          Array(242.0, 242.0, 242.0, 241.0, 242.0),
-          Array(241.0, 240.0, 241.0, 243.0, 241.0))
+        sample = randVar_1
       }
 
     val sampleArray = Nd4j.create(sample)

--- a/src/test/scala/org/dia/tensors/BasicTensorTest.scala
+++ b/src/test/scala/org/dia/tensors/BasicTensorTest.scala
@@ -523,7 +523,25 @@ class BasicTensorTest extends FunSuite {
 
     assert(cubeTensor == solutionTensor)
     //val k = cubeTensor((0,1))
+  }
 
+  test("std") {
+    val sample = (0d to 27d by 1d).toArray
+    val solution = (0d to 8d by 1d).map(p => 9.0).toArray
+    val cube = Nd4j.create(sample, Array(3,3,3))
+    val solCube = Nd4j.create(solution, Array(3,3))
+    val cubeTensor = new Nd4jTensor(cube)
+    val solutionTensor = new Nd4jTensor(solCube)
+    val std = cubeTensor.std(0)
+    assert(solutionTensor == std)
+  }
 
+  test("skew") {
+    val sample = (0d to 27d by 1d).toArray
+    val cube = Nd4j.create(sample, Array(3,3,3))
+    val cubeTensor = new Nd4jTensor(cube)
+    val skw = cubeTensor.skew(0)
+    val zeroSkew = new Nd4jTensor(Nd4j.zeros(3,3))
+    assert(skw == zeroSkew)
   }
 }

--- a/src/test/scala/org/dia/tensors/BasicTensorTest.scala
+++ b/src/test/scala/org/dia/tensors/BasicTensorTest.scala
@@ -326,6 +326,25 @@ class BasicTensorTest extends FunSuite {
     }   
   }
 
+  test("broadcastmatrixSubtraction"){
+    logger.info("In broadcastmatrixSubtraction")
+    val array = randVar
+    val flattened = array.flatten
+    val cascadedArray = flattened ++ flattened ++ flattened
+    val square = Nd4j.create(array)
+
+    val squareTensor = new Nd4jTensor(square)
+    val cubeTensor = new Nd4jTensor((cascadedArray, Array(3) ++ squareTensor.shape))
+    val cubeTensorShape = cubeTensor.shape
+    val zeroTensor = cubeTensor.zeros(cubeTensorShape: _*)
+    print(squareTensor.shape.toList)
+    print(cubeTensorShape.toList)
+    val broadcastSquareTensor = squareTensor.broadcast(Array(3, 6, 5))
+    print(broadcastSquareTensor.shape.toList)
+    val subtractTensor = cubeTensor - broadcastSquareTensor
+    assert(subtractTensor == zeroTensor)
+  }
+
   test("matrixDivision"){
     logger.info("In matrixDivision test ...")
     logger.info("The sciTensor is: "+ uSRDD.collect().toList)

--- a/src/test/scala/org/dia/tensors/BasicTensorTest.scala
+++ b/src/test/scala/org/dia/tensors/BasicTensorTest.scala
@@ -40,6 +40,25 @@ class BasicTensorTest extends FunSuite {
   val logger = org.slf4j.LoggerFactory.getLogger(this.getClass)
 
   /**
+   * Test statistical operations
+   **/
+  test("mean") {
+    logger.info("In mean test ...")
+    val array = randVar
+    val flattened = array.flatten
+    val cascadedArray = flattened ++ flattened ++ flattened
+    val square = Nd4j.create(array)
+
+    val squareTensor = new Nd4jTensor(square)
+    logger.info("The square shape is " + squareTensor.shape.toList)
+    val cubeTensor = new Nd4jTensor((cascadedArray, Array(3) ++ squareTensor.shape))
+
+    val averagedCube = cubeTensor.mean(0)
+
+    assert(averagedCube == squareTensor)
+  }
+
+  /**
   * Test relational operators
   **/
 

--- a/src/test/scala/org/dia/tensors/BasicTensorTest.scala
+++ b/src/test/scala/org/dia/tensors/BasicTensorTest.scala
@@ -43,6 +43,15 @@ class BasicTensorTest extends FunSuite {
   * Test relational operators
   **/
 
+  test("reshape") {
+    logger.info("In reshape test ...")
+    val cube = Nd4j.create((1d to 16d by 1d).toArray, Array(2,2,2,2))
+    val square = Nd4j.create((1d to 16d by 1d).toArray, Array(4,4))
+    val cubeTensor = new Nd4jTensor(cube)
+    val squareTensor = new Nd4jTensor(square)
+    val reshapedcubeTensor = cubeTensor.reshape(Array(4,4))
+    assert(reshapedcubeTensor == squareTensor)
+  }
   test("filter") {
     logger.info("In filter test ...")
     val dense = Nd4j.create(Array[Double](1, 241, 241, 1), Array(2, 2))
@@ -441,7 +450,7 @@ class BasicTensorTest extends FunSuite {
     val tdefault = sRDD.map(p => (p.data, p.shape))
     val varDataDef = tdefault.collect()(0)
     logger.info("The varInUse default data is: "+ varDataDef._1.mkString(" ") + "\nShape: (" + varDataDef._2.mkString(" , ")+")")
-    
+
     if (!(varData._1.sameElements(varData1._1)) && (varData1._1.sameElements(varDataDef._1))){
       assert(true)
     }else{

--- a/src/test/scala/org/dia/tensors/BasicTensorTest.scala
+++ b/src/test/scala/org/dia/tensors/BasicTensorTest.scala
@@ -509,4 +509,21 @@ class BasicTensorTest extends FunSuite {
     val detrended = cubeTensor.detrend(0)
     assert(detrended == solutionTensor)
   }
+
+  test("assign") {
+    val sample = (1d to 27d by 1d).toArray
+    val solution = sample.map(p => if (p < 10) 3 else p)
+    val cube = Nd4j.create(sample, Array(3,3,3))
+    val cubeTensor = new Nd4jTensor(cube)
+    val solutionCube = Nd4j.create(solution, Array(3,3,3))
+    val solutionTensor = new Nd4jTensor(solutionCube)
+
+    val slice_1 = cubeTensor.slice((0,1))
+    slice_1.assign(new Nd4jTensor(Array(3,3,3,3,3,3,3,3,3), Array(3,3)))
+
+    assert(cubeTensor == solutionTensor)
+    //val k = cubeTensor((0,1))
+
+
+  }
 }

--- a/src/test/scala/org/dia/tensors/ComparisonTest.scala
+++ b/src/test/scala/org/dia/tensors/ComparisonTest.scala
@@ -35,6 +35,13 @@ class ComparisonTest extends FunSuite {
     Array(0.0, 1.0, 0.0004003492849200234294, 2.0, 1.0),
     Array(2.0, 3.0, 4.0, 1.0, 2.0))
 
+  val ArraySampleCascade = Array(
+    ArraySample,
+    ArraySample,
+    ArraySample,
+    ArraySample
+  )
+
   val sample = Nd4j.create(ArraySample)
   val shapePair = (sample.data.asDouble, sample.shape)
 


### PR DESCRIPTION

PDFClustering based on Anomalies.
The PDFClusteringAnomalies.scala file consists of reading in a
single netcdf file into an RDD and performing various stastical operations,
such as detrending, mean along the axis, standard deviation along the axis, etc.

These are functionalities required for Alex Goodman's implementation of the PDFClustering
algorithm. This pull request is more so for those specific functions written in
SciTensor, AbstractTensor, Nd4jTensor, and BreezeTensor.

Note that the current implementation of PDFClustering does not use any sort of parallelism,
even though there are RDDs being used. It's an RDD of one partition.

I plan on parallelizing the detrend,std, and mean along axis by splitting by space.